### PR TITLE
修正 babel 找不到 preset 的问题

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ function copyPolyFill (shimPath, dest) {
       // 第一次批量处理
       contents =  babel.transform(contents, {
         presets: [
-          ['es2015',  { modules: false }]
+          [require.resolve('babel-preset-es2015'),  { modules: false }]
         ],
         comments: false,
       }).code


### PR DESCRIPTION
fixes #2 .
不仅是 windows 下会存在问题，只要是以全局包的形式 (`npm i -g wx-alipay`) 使用 `wxToalipay` 都会使 babel 在 cwd 寻找 preset，导致出现 `Couldn't find preset "es2015" relative to directory` 的异常。

将 `presets` 中的字符串替换为 `require.resolve(...)` 的绝对路径结果可修正该问题。
