### PR TITLE
修正依赖包大小写

### DIFF
--- a/lib/wxss/index.js
+++ b/lib/wxss/index.js
@@ -1,4 +1,4 @@
-const CssDom = require('CssDom')
+const CssDom = require('cssdom')
 
 
 function tagReplace (selectors) {


### PR DESCRIPTION
在大小写敏感的系统中（例如 Ubuntu），不严格的包名会直接崩溃。