### PR TITLE
使用相对路径加载 shim

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const wxsToJs = require('./lib/wxs/index')
 const svgToPng = require('./lib/svg/index')
 const fs = require('file-system')
 const path = require('path')
+const posix = require('ensure-posix-path')
 
 
 // 获取文件格式
@@ -33,7 +34,7 @@ function getFilePath (filepath) {
 }
 
 function jsToAliHelp (relative, code) {
-  let destPath = path.relative(relative, 'my.shim.js').replace('../', '')
+  let destPath = `./${posix(path.relative(path.dirname(relative), 'my.shim.js'))}`
 
   // 追加polyfill
    code = `var _myShim = require('${destPath}');

--- a/lib/js/helpers.js
+++ b/lib/js/helpers.js
@@ -2,10 +2,11 @@ const template = require('@babel/template')
 const generate = require('@babel/generator').default
 const path = require('path')
 const defineHelper = template.program({ placeholderPattern: false });
+const posix = require('ensure-posix-path')
 
 
 exports.requireReflect = function (relative) {
-  let destPath = path.relative(relative, 'es.reflect').replace('../', '')
+  let destPath = `./${posix(path.relative(path.dirname(relative), 'es.reflect'))}`
 
   let result = defineHelper(`var Reflect = require('${destPath}');`)()
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "babel-core": "^6.26.0",
     "babel-preset-es2015": "^6.24.1",
     "cssdom": "^1.0.21",
+    "ensure-posix-path": "^1.0.2",
     "file-system": "^2.2.2",
     "htmldom": "^3.0.4"
   }


### PR DESCRIPTION
fixes #1 
[在 win32 环境里，目录分隔符是 `\`](https://nodejs.org/dist/latest-v10.x/docs/api/path.html#path_path_sep)，所以会导致 #1 的异常发生。